### PR TITLE
fix airbrake host configuration

### DIFF
--- a/lib/winston-airbrake.js
+++ b/lib/winston-airbrake.js
@@ -11,7 +11,7 @@ var Airbrake = exports.Airbrake = winston.transports.Airbrake = function (option
 
   if (options.apiKey) {
     this.airbrakeClient = airbrake.createClient(options.apiKey);
-    this.airbrakeClient.host = options.host;
+    this.airbrakeClient.serviceHost = options.host;
     this.airbrakeClient.protocol = options.protocol || 'http';
     this.airbrakeClient.handleExceptions = this.handleExceptions;
   } else {


### PR DESCRIPTION
this fixes a bug in winston-airbrake so that you can correctly set the serviceHost to use errbit.  previously, it was attempting to set `host`, but the node `airbrake` instead wants `serviceHost`.
