### PR TITLE
- Added support for custom serviceHost & added explanation to documentat...

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Options:
 
 * __apiKey:__ Valid Airbrake API Key (required)
 * __host:__ Your host, to be displayed in Airbrake. (default: require('os').hostname())
+* __serviceHost:__ The host to send the Airbrake exceptions to. (default: api.airbrake.io)
 
 ## Extended example of usage
 ``` js

--- a/lib/winston-airbrake.js
+++ b/lib/winston-airbrake.js
@@ -14,6 +14,7 @@ var Airbrake = exports.Airbrake = winston.transports.Airbrake = function (option
     this.airbrakeClient.serviceHost = options.host;
     this.airbrakeClient.protocol = options.protocol || 'http';
     this.airbrakeClient.handleExceptions = this.handleExceptions;
+    this.airbrakeClient.serviceHost = options.serviceHost || this.airbrakeClient.serviceHost;
   } else {
     throw "You must specify an airbrake API Key to use winston-airbrake";
   }


### PR DESCRIPTION
I intended to send my errors to CodebaseHQ, they receive the airbrake errors but you need to modify the serviceHost so the exceptions are send to the right 'service'. 

I thought it would be a good idea to add this to this package.
