### PR TITLE
serviceHost should be host for options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Options:
 * __silent:__ Boolean flag indicating whether to suppress output. (default: false)
 
 * __apiKey:__ Valid Airbrake API Key (required)
-* __serviceHost:__ Your host, to be displayed in Airbrake. (default: require('os').hostname())
+* __host:__ Your host, to be displayed in Airbrake. (default: require('os').hostname())
 
 ## Extended example of usage
 ``` js
@@ -34,7 +34,7 @@ Options:
 
   var options = {
     "apiKey":"YOUR_API_KEY",
-    "serviceHost":"YOUR_DOMAIN"
+    "host":"YOUR_DOMAIN"
   };
   winston.add(Airbrake, options);
 


### PR DESCRIPTION
While the key sent to Airbrake is serviceHost, the options object expects host.

Fixes #3 - cc: @ostap0207