### PR TITLE
Use default serviceHost if options.host does not passed

### DIFF
--- a/lib/winston-airbrake.js
+++ b/lib/winston-airbrake.js
@@ -11,7 +11,7 @@ var Airbrake = exports.Airbrake = winston.transports.Airbrake = function (option
 
   if (options.apiKey) {
     this.airbrakeClient = airbrake.createClient(options.projectId, options.apiKey);
-    this.airbrakeClient.serviceHost = options.host;
+    this.airbrakeClient.serviceHost = options.host || this.airbrakeClient.serviceHost;
     this.airbrakeClient.protocol = options.protocol || 'http';
     this.airbrakeClient.handleExceptions = this.handleExceptions;
     this.airbrakeClient.env = options.env || 'production';


### PR DESCRIPTION
Current implementation rewrite default airbrake server if `options.host` doesn't passed.
This PR fix it